### PR TITLE
Config from handout

### DIFF
--- a/5etoolsR20.user.js
+++ b/5etoolsR20.user.js
@@ -72,7 +72,7 @@ var D20plus = function(version) {
 		spells: {},
 		items: {},
 		initiative: {},
-        config: {}
+		config: {}
 	};
 
 	d20plus.scripts = [
@@ -131,36 +131,36 @@ var D20plus = function(version) {
 		return "?" + (new Date()).getTime();
 	};
 
-    d20plus.loadConfig = function() {
-        var configHandout = d20.Campaign.handouts.models.find(function(handout) { return handout.attributes.name.toLowerCase() == '5etools';});
-        if(configHandout) {
-            configHandout.view.render();
-            configHandout._getLatestBlob("notes", function(notes) {
-            	var decoded = decodeURIComponent(notes);
+	d20plus.loadConfig = function() {
+		var configHandout = d20.Campaign.handouts.models.find(function(handout) { return handout.attributes.name.toLowerCase() == '5etools';});
+		if(configHandout) {
+			configHandout.view.render();
+			configHandout._getLatestBlob("notes", function(notes) {
+				var decoded = decodeURIComponent(notes);
 
-	            notes = decoded.split("<br>");
+				notes = decoded.split("<br>");
 
-	            notes.forEach(function(item, index) {
-	                var option = item.split(":").map(function(o) {
-					  return o.trim();
+				notes.forEach(function(item, index) {
+					var option = item.split(":").map(function(o) {
+						return o.trim();
 					});
-	                d20plus.config[option[0]] = option[1];
-	            });
+					d20plus.config[option[0]] = option[1];
+				});
 
-	            d20plus.log("> Config Loaded:");
-	            d20plus.log(d20plus.config);
+				d20plus.log("> Config Loaded:");
+				d20plus.log(d20plus.config);
 
 
-              /* JSON Version, deemed too difficult for users
+				/* JSON Version, deemed too difficult for users, but maybe useful in the future
 
-              var brRemoved = decoded.split("<br>").join("");
-              notes = JSON.parse(brRemoved);
-              d20plus.config = notes;
-              d20plus.log("> Config Loaded");
-              */
-            });
-        }
-    };
+				var brRemoved = decoded.split("<br>").join("");
+				notes = JSON.parse(brRemoved);
+				d20plus.config = notes;
+				d20plus.log("> Config Loaded");
+				*/
+			});
+		}
+	};
 
 	// Window loaded
 	window.onload = function() {
@@ -176,8 +176,8 @@ var D20plus = function(version) {
 	// Page fully loaded and visible
 	d20plus.Init = function() {
 		d20plus.log("> Init (v" + d20plus.version + ")");
-        d20plus.log("> Reading Config...");
-        d20plus.loadConfig();
+		d20plus.log("> Reading Config...");
+		d20plus.loadConfig();
 		d20plus.bindDropLocations();
 		// Firebase will deny changes if we're not GM. Better to fail gracefully.
 		if (window.is_gm) {

--- a/5etoolsR20.user.js
+++ b/5etoolsR20.user.js
@@ -220,10 +220,13 @@ var D20plus = function(version) {
 								if (i in barsList) {
 									var barName = i;
 									var barAttr = v;
-									var barVal = character.attribs.find(function(a) {return a.get("name") == barAttr;}).get("current");
+									var charAttr = character.attribs.find(function(a) {return a.get("name") == barAttr;});
+									var barVal = charAttr ? charAttr.get("current") : "";
 									e.attributes[barName + "_value"] = barVal;
 									if (d20plus.config[barName + "_max"]) {
-										e.attributes[barName + "_value"] = barVal;
+										e.attributes[barName + "_max"] = barVal;
+									} else {
+										e.attributes[barName + "_max"] = null;
 									};
 								}
 							});

--- a/5etoolsR20.user.js
+++ b/5etoolsR20.user.js
@@ -213,9 +213,25 @@ var D20plus = function(version) {
 						var npc = character.attribs.find(function(a) {return a.get("name").toLowerCase() == "npc";});
 						var isNPC = npc ? parseInt(npc.get("current")) : 0;
 						if (isNPC) {
-							var barName = Object.find(d20plus.config, "hp");
-							if (d20plus.config.rollHP && barName) {
+
+							// Set bars
+							$.each(d20plus.config, function(i, v) {
+								var barsList = {bar1:1, bar2:1, bar3:1};
+								if (i in barsList) {
+									var barName = i;
+									var barAttr = v;
+									var barVal = character.attribs.find(function(a) {return a.get("name") == barAttr;}).get("current");
+									e.attributes[barName + "_value"] = barVal;
+									if (d20plus.config[barName + "_max"]) {
+										e.attributes[barName + "_value"] = barVal;
+									};
+								}
+							});
+
+							// Roll HP
+							if (d20plus.config.rollHP && Object.find(d20plus.config, "HP")) {
 								var hpf = character.attribs.find(function(a) {return a.get("name").toLowerCase() == "npc_hpformula";});
+								var barName = Object.find(d20plus.config, "HP");
 								if (hpf) {
 									var hpformula = hpf.get("current");
 									if (hpformula) {
@@ -789,38 +805,6 @@ var D20plus = function(version) {
 							light_radius: lightradius,
 							light_dimradius: lightmin
 						};
-
-						if (d20plus.config.bar1) {
-							console.log("bar1 found");
-							var barAttr = d20plus.config.bar1;
-							console.log("it's " + barAttr);
-							var barVal = barAttr in {"hp":1, "ac":1} ? data[barAttr].match(/^\d+/) : data[barAttr];
-							console.log("val should be" + barVal);
-							defaulttoken["bar1_value"] = barVal;
-							if (d20plus.config.bar1_max) {
-								defaulttoken["bar1_max"] = barVal;
-							};
-						};
-
-						if (d20plus.config.bar2) {
-							var barAttr = d20plus.config.bar2;
-							var barVal = barAttr in {"hp":1, "ac":1} ? data[barAttr].match(/^\d+/) : data[barAttr];
-							defaulttoken["bar2_value"] = barVal;
-							if (d20plus.config.bar2_max) {
-								defaulttoken["bar2_max"] = barVal;
-							};
-						};
-
-						if (d20plus.config.bar3) {
-							var barAttr = d20plus.config.bar3;
-							var barVal = barAttr in {"hp":1, "ac":1} ? data[barAttr].match(/^\d+/) : data[barAttr];
-							defaulttoken["bar3_value"] = barVal;
-							if (d20plus.config.bar3_max) {
-								defaulttoken["bar3_max"] = barVal;
-							};
-						};
-
-						console.log(defaulttoken);
 
 						character.updateBlobs({ avatar: avatar, defaulttoken: JSON.stringify(defaulttoken) });
 						character.save({defaulttoken: (new Date()).getTime()});

--- a/5etoolsR20.user.js
+++ b/5etoolsR20.user.js
@@ -71,7 +71,8 @@ var D20plus = function(version) {
 		monsters: {},
 		spells: {},
 		items: {},
-		initiative: {}
+		initiative: {},
+        config: {}
 	};
 
 	d20plus.scripts = [
@@ -130,6 +131,30 @@ var D20plus = function(version) {
 		return "?" + (new Date).getTime();
 	}
 
+    d20plus.loadConfig = function() {
+        var configHandout = d20.Campaign.handouts.models.find(function(handout) { return handout.attributes.name.toLowerCase() == '5etools';});
+        if(configHandout) {
+            configHandout.view.render();
+            configHandout._getLatestBlob("notes", function(notes) {
+              var decoded = decodeURIComponent(notes);
+              var brRemoved = decoded.split("<br>").join("");
+              notes = JSON.parse(brRemoved);
+              d20plus.config = notes;
+              d20plus.log("> Config Loaded");
+
+              /* Alternative code for non-JSON config
+
+                notes = decodeURIComponent(notes).split("<br>");
+                notes.forEach(function(item, index) {
+                    var option = item.split(":");
+                    d20plus.config[option[0]] = option[1];
+                });
+
+              */
+            });
+        }
+    }
+
 	// Window loaded
 	window.onload = function() {
 		window.unwatch("d20");
@@ -144,6 +169,8 @@ var D20plus = function(version) {
 	// Page fully loaded and visible
 	d20plus.Init = function() {
 		d20plus.log("> Init (v" + d20plus.version + ")");
+        d20plus.log("> Reading Config...");
+        d20plus.loadConfig();
 		d20plus.bindDropLocations();
 		// Firebase will deny changes if we're not GM. Better to fail gracefully.
 		if (window.is_gm) {


### PR DESCRIPTION
A lot of this is parser error/warning correction, sorry. Missing semicolons and such.

## The Initial Suggestion / Issue
I did not like the way token bar values were being set on import as well as token drop. These values were hardcoded, no way to adjust to personal preference or enable/disable rolling HP. Personal preferences need to be saved SOMEWHERE, so I came up with storing configuration values in a handout inside Roll20.

## The Changes
The main chunks are the new `loadConfig` function which is called during `init`, and the changes to the `bindGraphics` function. `loadConfig` will search for and parse a handout named `5etools`. This handout is a simple, flat index: value per line. Currently the script is making use of `bar#`, `bar#_max`, and `rollHP`. Example config setup:
```
bar1: HP
bar1_max: true
bar3: AC
rollHP: true
```
When importing a monster, defaultToken is no longer set with the bar values, this change now occurs on token drop, and only if there are values defined in configuration. Similarly, rolling for HP is disabled unless set to true in config. Having no config allows a token to be untouched on drop.

## Todo
Setting token name / bar display options as well as light/sight options are easily in scope for this.