### PR TITLE
Monster rays import fix and accidentally everything else

### DIFF
--- a/5etoolsR20.user.js
+++ b/5etoolsR20.user.js
@@ -2,7 +2,7 @@
 // @name         5etoolsR20
 // @namespace    https://github.com/astranauta/
 // @license      MIT (https://opensource.org/licenses/MIT)
-// @version      0.5.26
+// @version      0.5.27
 // @updateURL    https://github.com/astranauta/5etoolsR20/raw/master/5etoolsR20.user.js
 // @downloadURL  https://github.com/astranauta/5etoolsR20/raw/master/5etoolsR20.user.js
 // @description  Enhance your Roll20 experience
@@ -37,8 +37,8 @@ var D20plus = function(version) {
 	d20plus.scripts = [
 		{name: "xml2json", url: "https://cdnjs.cloudflare.com/ajax/libs/x2js/1.2.0/xml2json.min.js"},
 		{name: "listjs", url: "https://raw.githubusercontent.com/javve/list.js/v1.5.0/dist/list.min.js"},
-		{name: "5etoolsutils", url: "https://5etools.com/master/js/utils.js"},
-		{name: "5etoolsrender", url: "https://5etools.com/master/js/entryrender.js"}
+		{name: "5etoolsutils", url: "https://5etools.com/js/utils.js"},
+		{name: "5etoolsrender", url: "https://5etools.com/js/entryrender.js"}
 	];
 
 	// Inject external JS libraries

--- a/5etoolsR20.user.js
+++ b/5etoolsR20.user.js
@@ -1317,12 +1317,12 @@ var D20plus = function(version) {
 								} else {
 									text = v.text;
 								}
-								var actiontext = "";
-								if (v.text instanceof Array) {
-									actiontext = v.text[0];
-								} else {
-									actiontext = v.text;
-								}
+								var actiontext = text;
+								// if (v.text instanceof Array) {
+								// 	actiontext = v.text[0];
+								// } else {
+								// 	actiontext = v.text;
+								// }
 								var action_desc = actiontext; // required for later reduction of information dump.
 								var rollbase = "@{wtype}&{template:npcaction} @{attack_display_flag} @{damage_flag} {{name=@{npc_name}}} {{rname=@{name}}} {{r1=[[1d20+(@{attack_tohit}+0)]]}} @{rtype}+(@{attack_tohit}+0)]]}} {{dmg1=[[@{attack_damage}+0]]}} {{dmg1type=@{attack_damagetype}}} {{dmg2=[[@{attack_damage2}+0]]}} {{dmg2type=@{attack_damagetype2}}} {{crit1=[[@{attack_crit}+0]]}} {{crit2=[[@{attack_crit2}+0]]}} {{description=@{description}}} @{charname_output}";
 								// attack parsing


### PR DESCRIPTION
When monster action text is an array as in the case of Beholder Rays and supposedly breath weapons, the actiontext was being set to only the value of the first index, while a full text string was previously being assembled and seemingly unused.

I've corrected this to use the assembled full text string. 

Unfortunately I'm in a rush so this also includes all the changes of my previous PR, because I'm a horrible person. 

Also, merging to Dev so you can handle the version number and all that before release.